### PR TITLE
Add admin module with async db support

### DIFF
--- a/modules/admin.py
+++ b/modules/admin.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+from dotenv import load_dotenv
+import yaml
+import aiosqlite
+import asyncpg
+
+router = Router()
+
+_DB_TYPE = None
+
+
+def _get_db_type() -> str:
+    global _DB_TYPE
+    if _DB_TYPE is None:
+        db_type = os.getenv("DB_TYPE")
+        if not db_type and Path("config.yaml").exists():
+            with open("config.yaml", "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+                db_type = data.get("DB_TYPE")
+        _DB_TYPE = (db_type or "sqlite").lower()
+    return _DB_TYPE
+
+
+async def _connect():
+    db_type = _get_db_type()
+    if db_type == "postgres":
+        dsn = os.getenv("DATABASE_URL", "")
+        return await asyncpg.connect(dsn=dsn)
+    path = os.getenv("DATABASE_PATH", "database.db")
+    return await aiosqlite.connect(path)
+
+
+async def startup() -> None:
+    load_dotenv()
+    conn = await _connect()
+    db_type = _get_db_type()
+    if db_type == "postgres":
+        await conn.execute(
+            "CREATE TABLE IF NOT EXISTS admins(user_id BIGINT PRIMARY KEY)"
+        )
+        await conn.close()
+    else:
+        await conn.execute(
+            "CREATE TABLE IF NOT EXISTS admins(user_id INTEGER PRIMARY KEY)"
+        )
+        await conn.commit()
+        await conn.close()
+
+
+def _owner_only(func):
+    async def wrapper(message: Message, *args, **kwargs):
+        owner_id = int(os.environ.get("OWNER_ID", 0))
+        if message.from_user and message.from_user.id == owner_id:
+            return await func(message, *args, **kwargs)
+
+    return wrapper
+
+
+@router.message(Command("add_admin"))
+@_owner_only
+async def add_admin(message: Message) -> None:
+    parts = message.text.split()
+    if len(parts) != 2:
+        await message.answer("Usage: /add_admin <user_id>")
+        return
+    uid = int(parts[1])
+    conn = await _connect()
+    db_type = _get_db_type()
+    if db_type == "postgres":
+        await conn.execute(
+            "INSERT INTO admins(user_id) VALUES($1) ON CONFLICT DO NOTHING", uid
+        )
+        await conn.close()
+    else:
+        await conn.execute("INSERT OR IGNORE INTO admins(user_id) VALUES (?)", (uid,))
+        await conn.commit()
+        await conn.close()
+    await message.answer(f"Added admin {uid}")
+
+
+@router.message(Command("rm_admin"))
+@_owner_only
+async def rm_admin(message: Message) -> None:
+    parts = message.text.split()
+    if len(parts) != 2:
+        await message.answer("Usage: /rm_admin <user_id>")
+        return
+    uid = int(parts[1])
+    conn = await _connect()
+    db_type = _get_db_type()
+    if db_type == "postgres":
+        await conn.execute("DELETE FROM admins WHERE user_id=$1", uid)
+        await conn.close()
+    else:
+        await conn.execute("DELETE FROM admins WHERE user_id=?", (uid,))
+        await conn.commit()
+        await conn.close()
+    await message.answer(f"Removed admin {uid}")
+
+
+@router.message(Command("list_admin"))
+@_owner_only
+async def list_admin(message: Message) -> None:
+    conn = await _connect()
+    db_type = _get_db_type()
+    if db_type == "postgres":
+        rows = await conn.fetch("SELECT user_id FROM admins")
+        admins = [str(r["user_id"]) for r in rows]
+        await conn.close()
+    else:
+        cursor = await conn.execute("SELECT user_id FROM admins")
+        rows = await cursor.fetchall()
+        admins = [str(r[0]) for r in rows]
+        await conn.close()
+    text = ", ".join(admins) if admins else "No admins."
+    await message.answer(text)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import os
+
+import pytest
+
+from modules import admin
+
+
+class FakeFrom:
+    def __init__(self, user_id):
+        self.id = user_id
+
+
+class FakeMessage:
+    def __init__(self, text, user_id):
+        self.text = text
+        self.from_user = FakeFrom(user_id)
+        self.responses: list[str] = []
+
+    async def answer(self, text: str) -> None:
+        self.responses.append(text)
+
+
+def setup_env(tmp_path):
+    os.environ["OWNER_ID"] = "1"
+    os.environ["DB_TYPE"] = "sqlite"
+    os.environ["DATABASE_PATH"] = str(tmp_path / "test.db")
+
+
+@pytest.mark.asyncio
+async def test_admin_commands(tmp_path):
+    setup_env(tmp_path)
+    await admin.startup()
+
+    m = FakeMessage("/add_admin 2", 1)
+    await admin.add_admin(m)
+    assert m.responses[-1] == "Added admin 2"
+
+    m = FakeMessage("/list_admin", 1)
+    await admin.list_admin(m)
+    assert m.responses[-1] == "2"
+
+    m = FakeMessage("/rm_admin 2", 1)
+    await admin.rm_admin(m)
+    assert m.responses[-1] == "Removed admin 2"
+
+    m = FakeMessage("/list_admin", 1)
+    await admin.list_admin(m)
+    assert m.responses[-1] == "No admins."


### PR DESCRIPTION
## Summary
- implement `modules/admin.py` with admin command handlers
- add package init and test coverage

## Testing
- `ruff check modules/admin.py tests/test_admin.py modules/__init__.py`
- `black modules/admin.py tests/test_admin.py modules/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a41d19490832e8b83f44455680835